### PR TITLE
Rename RESTful Exporter and Handle Function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 # Created by https://www.toptal.com/developers/gitignore/api/kotlin,intellij,gradle
 # Edit at https://www.toptal.com/developers/gitignore?templates=kotlin,intellij,gradle
 
+.DS_Store
+
 ### Intellij ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/src/main/kotlin/de/tum/in/ase/apodini/Handler.kt
+++ b/src/main/kotlin/de/tum/in/ase/apodini/Handler.kt
@@ -6,7 +6,7 @@ import de.tum.`in`.ase.apodini.modifiers.Modifier
 import kotlinx.coroutines.CoroutineScope
 
 interface Handler<Output> : ModifiableComponent<Handler<Output>> {
-    suspend fun CoroutineScope.compute(): Output
+    suspend fun CoroutineScope.handle(): Output
 
     override fun modify(modifier: Modifier): Handler<Output> {
         return ModifiedHandler(this, listOf(modifier))

--- a/src/main/kotlin/de/tum/in/ase/apodini/WebService.kt
+++ b/src/main/kotlin/de/tum/in/ase/apodini/WebService.kt
@@ -1,12 +1,12 @@
 package de.tum.`in`.ase.apodini
 
 import de.tum.`in`.ase.apodini.configuration.ConfigurationBuilder
-import de.tum.`in`.ase.apodini.exporter.RESTExporter
+import de.tum.`in`.ase.apodini.exporter.REST
 import de.tum.`in`.ase.apodini.model.semanticModel
 
 interface WebService: Component {
     fun ConfigurationBuilder.configure() {
-        use(RESTExporter())
+        use(REST())
     }
 }
 

--- a/src/main/kotlin/de/tum/in/ase/apodini/exporter/REST.kt
+++ b/src/main/kotlin/de/tum/in/ase/apodini/exporter/REST.kt
@@ -6,7 +6,6 @@ import de.tum.`in`.ase.apodini.model.SemanticModel
 import de.tum.`in`.ase.apodini.properties.options.HTTPParameterMode
 import de.tum.`in`.ase.apodini.properties.options.http
 import de.tum.`in`.ase.apodini.request.Request
-import de.tum.`in`.ase.apodini.types.BooleanType.encode
 import de.tum.`in`.ase.apodini.types.Encoder
 import de.tum.`in`.ase.apodini.types.Object
 import io.ktor.application.*
@@ -20,11 +19,10 @@ import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.util.pipeline.*
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.runBlocking
 import java.util.*
 
-class RESTExporter(
-    private val port: Int = 8080,
+class REST(
+    private val port: Int = 80,
 ): Exporter {
     override fun export(model: SemanticModel) {
         val endpoints = model.endpoints.map { EvaluatedEndpoint(model, it) }
@@ -165,7 +163,7 @@ private fun <T> SemanticModel.Result<T>.encode(
     encoder.keyed {
         encode("_links") {
             keyed {
-                encode("_self") {
+                encode("self") {
                     encodeString(linkToSelf.relativeURL(request.context.context.request, endpoints))
                 }
                 links.forEach { link ->

--- a/src/main/kotlin/de/tum/in/ase/apodini/impl/text.kt
+++ b/src/main/kotlin/de/tum/in/ase/apodini/impl/text.kt
@@ -10,7 +10,7 @@ fun ComponentBuilder.text(response: String): ModifiableComponent<*> {
 }
 
 private class Text(val response: String): Handler<String> {
-    override suspend fun CoroutineScope.compute(): String {
+    override suspend fun CoroutineScope.handle(): String {
         return response
     }
 }

--- a/src/main/kotlin/de/tum/in/ase/apodini/internal/wrappers.kt
+++ b/src/main/kotlin/de/tum/in/ase/apodini/internal/wrappers.kt
@@ -22,7 +22,7 @@ internal class ModifiedComponent(private val component: Component, private val m
 }
 
 internal class ModifiedHandler<T>(val handler: Handler<T>, val modifiers: List<Modifier>) : Handler<T> {
-    override suspend fun CoroutineScope.compute(): T {
+    override suspend fun CoroutineScope.handle(): T {
         throw IllegalArgumentException(
             "Unexpected call to `compute` to a handler wrapped in modifiers"
         )

--- a/src/main/kotlin/de/tum/in/ase/apodini/model/SemanticModel.kt
+++ b/src/main/kotlin/de/tum/in/ase/apodini/model/SemanticModel.kt
@@ -135,7 +135,7 @@ class SemanticModel internal constructor(
                     property.update()
                 }
 
-                val value = with(newInstance) { delegatedRequest.compute() }
+                val value = with(newInstance) { delegatedRequest.handle() }
                 val selfLink = selfEndpoint.link(value, request)!!
                 val links = linkedEndpoints.mapNotNull { it.link(value, request) }
                 return Result(value, typeDefinition, selfLink, links)

--- a/src/test/kotlin/de/tum/in/ase/apodini/test/RequestHandlingTest.kt
+++ b/src/test/kotlin/de/tum/in/ase/apodini/test/RequestHandlingTest.kt
@@ -29,7 +29,7 @@ class RequestHandlingTest : TestCase() {
     fun testObject() {
         val result = handle {
             +object : Handler<Foo> {
-                override suspend fun CoroutineScope.compute(): Foo {
+                override suspend fun CoroutineScope.handle(): Foo {
                     return Foo("Test", 42)
                 }
             }
@@ -41,7 +41,7 @@ class RequestHandlingTest : TestCase() {
     fun testArray() {
         val result = handle {
             +object : Handler<List<Int>> {
-                override suspend fun CoroutineScope.compute(): List<Int> {
+                override suspend fun CoroutineScope.handle(): List<Int> {
                     return listOf(1, 2, 3)
                 }
             }
@@ -55,7 +55,7 @@ class RequestHandlingTest : TestCase() {
             +object : Handler<String> {
                 val name by parameter<String>()
 
-                override suspend fun CoroutineScope.compute(): String {
+                override suspend fun CoroutineScope.handle(): String {
                     return "Hello, $name!"
                 }
             }
@@ -71,7 +71,7 @@ class RequestHandlingTest : TestCase() {
                 +object : Handler<String> {
                     val id by pathParameter
 
-                    override suspend fun CoroutineScope.compute(): String {
+                    override suspend fun CoroutineScope.handle(): String {
                         return "Hello from $id"
                     }
                 }
@@ -87,7 +87,7 @@ class RequestHandlingTest : TestCase() {
                 +object : Handler<String> {
                     val someSecret by environment { secret }
 
-                    override suspend fun CoroutineScope.compute(): String {
+                    override suspend fun CoroutineScope.handle(): String {
                         return "Secret = $someSecret. Don't tell anyone"
                     }
                 }
@@ -103,7 +103,7 @@ class RequestHandlingTest : TestCase() {
                 +object : Handler<String> {
                     val someSecret by environment { secret }
 
-                    override suspend fun CoroutineScope.compute(): String {
+                    override suspend fun CoroutineScope.handle(): String {
                         return "Secret = $someSecret. Don't tell anyone"
                     }
                 }
@@ -118,7 +118,7 @@ class RequestHandlingTest : TestCase() {
         assertFailsWith<IllegalArgumentException> {
             handle {
                 +object : Handler<String> {
-                    override suspend fun CoroutineScope.compute(): String {
+                    override suspend fun CoroutineScope.handle(): String {
                         throw IllegalArgumentException("Nope")
                     }
                 }.withEnvironment { logger { logger } }

--- a/src/test/kotlin/de/tum/in/ase/apodini/test/SemanticModelBuilderTest.kt
+++ b/src/test/kotlin/de/tum/in/ase/apodini/test/SemanticModelBuilderTest.kt
@@ -4,7 +4,7 @@ import de.tum.`in`.ase.apodini.Component
 import de.tum.`in`.ase.apodini.ComponentBuilder
 import de.tum.`in`.ase.apodini.Handler
 import de.tum.`in`.ase.apodini.environment.EnvironmentKey
-import de.tum.`in`.ase.apodini.exporter.RESTExporter
+import de.tum.`in`.ase.apodini.exporter.REST
 import de.tum.`in`.ase.apodini.impl.group
 import de.tum.`in`.ase.apodini.impl.text
 import de.tum.`in`.ase.apodini.model.Operation
@@ -36,7 +36,7 @@ internal class SemanticModelBuilderTest : TestCase() {
             text("Hello World")
         }
         assertEquals(semanticModel.exporters.count(), 1)
-        assert(semanticModel.exporters.first() is RESTExporter)
+        assert(semanticModel.exporters.first() is REST)
         assert(semanticModel.globalEnvironment.keys.isEmpty())
         assertEquals(semanticModel.endpoints.count(), 1)
 
@@ -51,7 +51,7 @@ internal class SemanticModelBuilderTest : TestCase() {
     fun testCustomHandlerWithOptionalString() {
         val semanticModel = semanticModel {
             +object : Handler<String?> {
-                override suspend fun CoroutineScope.compute(): String? {
+                override suspend fun CoroutineScope.handle(): String? {
                     return null
                 }
             }
@@ -70,7 +70,7 @@ internal class SemanticModelBuilderTest : TestCase() {
             +object : Handler<String> {
                 val name by parameter<String?>()
 
-                override suspend fun CoroutineScope.compute(): String {
+                override suspend fun CoroutineScope.handle(): String {
                     return "Hello, ${name ?: "World"}"
                 }
             }
@@ -95,7 +95,7 @@ internal class SemanticModelBuilderTest : TestCase() {
                     http { query }
                 }
 
-                override suspend fun CoroutineScope.compute(): String {
+                override suspend fun CoroutineScope.handle(): String {
                     return "Hello, $name"
                 }
             }
@@ -167,7 +167,7 @@ internal class SemanticModelBuilderTest : TestCase() {
                 +object : Handler<String> {
                     val id by pathId
 
-                    override suspend fun CoroutineScope.compute(): String {
+                    override suspend fun CoroutineScope.handle(): String {
                         return "User, $id"
                     }
                 }
@@ -206,7 +206,7 @@ internal class SemanticModelBuilderTest : TestCase() {
     fun testEnvironmentOnHandlerWithUnaryPlus() {
         val semanticModel = semanticModel {
             +object : Handler<String> {
-                override suspend fun CoroutineScope.compute(): String {
+                override suspend fun CoroutineScope.handle(): String {
                     return "Hello World"
                 }
             }.withEnvironment {
@@ -520,7 +520,7 @@ private val Parameter<*>.id: UUID
 private class PersonHandler(id: PathParameter) : Handler<Person> {
     val id by id
 
-    override suspend fun CoroutineScope.compute(): Person {
+    override suspend fun CoroutineScope.handle(): Person {
         return Person("Test")
     }
 }
@@ -528,19 +528,19 @@ private class PersonHandler(id: PathParameter) : Handler<Person> {
 private class ContentHandler(id: PathParameter) : Handler<Content> {
     val id by id
 
-    override suspend fun CoroutineScope.compute(): Content {
+    override suspend fun CoroutineScope.handle(): Content {
         return Content("hello world", "1")
     }
 }
 
 private object PersonHandlerWithoutId : Handler<Person> {
-    override suspend fun CoroutineScope.compute(): Person {
+    override suspend fun CoroutineScope.handle(): Person {
         return Person("Test")
     }
 }
 
 private object ContentHandlerWithoutId : Handler<Content> {
-    override suspend fun CoroutineScope.compute(): Content {
+    override suspend fun CoroutineScope.handle(): Content {
         return Content("hello world", "1")
     }
 }
@@ -559,7 +559,7 @@ private class Content(val text: String, @Hidden val personId: String) : CustomTy
 
 @Documented("Documented Handler")
 private object DocumentedHandler : Handler<String> {
-    override suspend fun CoroutineScope.compute(): String {
+    override suspend fun CoroutineScope.handle(): String {
         return "Hello, World!"
     }
 }

--- a/src/test/kotlin/de/tum/in/ase/apodini/test/example/SWAPI.kt
+++ b/src/test/kotlin/de/tum/in/ase/apodini/test/example/SWAPI.kt
@@ -9,7 +9,7 @@ import de.tum.`in`.ase.apodini.*
 import de.tum.`in`.ase.apodini.configuration.ConfigurationBuilder
 import de.tum.`in`.ase.apodini.environment.EnvironmentKey
 import de.tum.`in`.ase.apodini.environment.EnvironmentKeys
-import de.tum.`in`.ase.apodini.exporter.RESTExporter
+import de.tum.`in`.ase.apodini.exporter.REST
 import de.tum.`in`.ase.apodini.impl.group
 import de.tum.`in`.ase.apodini.impl.text
 import de.tum.`in`.ase.apodini.modifiers.ModifiableComponent
@@ -88,7 +88,7 @@ class SWAPI : WebService {
     }
 
     override fun ConfigurationBuilder.configure() {
-        use(RESTExporter(port = 8080))
+        use(REST(port = 8080))
 
         environment {
             store {
@@ -142,7 +142,7 @@ private inline fun <reified T> ComponentBuilder.itemRelationship(id: PathParamet
 
 private class AllItemsHandler<T>(val items: SWAPIStore.() -> Map<Int, T>) : Handler<List<T>> {
     val store by environment { store }
-    override suspend fun CoroutineScope.compute(): List<T> {
+    override suspend fun CoroutineScope.handle(): List<T> {
         return store.items().values.toList()
     }
 }
@@ -151,7 +151,7 @@ private class ItemHandler<T>(id: PathParameter, val items: SWAPIStore.() -> Map<
     val id by id
     val store by environment { store }
 
-    override suspend fun CoroutineScope.compute(): T {
+    override suspend fun CoroutineScope.handle(): T {
         return id.toIntOrNull()?.let { store.items()[it] } ?: throw NotFoundException()
     }
 }
@@ -160,7 +160,7 @@ private class ItemRelationshipHandler<T>(id: PathParameter, val items: SWAPIStor
     val id by id
     val store by environment { store }
 
-    override suspend fun CoroutineScope.compute(): T {
+    override suspend fun CoroutineScope.handle(): T {
         return id.toIntOrNull()?.let { store.items(it) } ?: throw NotFoundException()
     }
 }

--- a/src/test/kotlin/de/tum/in/ase/apodini/test/example/TestWebService.kt
+++ b/src/test/kotlin/de/tum/in/ase/apodini/test/example/TestWebService.kt
@@ -5,7 +5,7 @@ import de.tum.`in`.ase.apodini.configuration.ConfigurationBuilder
 import de.tum.`in`.ase.apodini.environment.EnvironmentKey
 import de.tum.`in`.ase.apodini.environment.EnvironmentKeys
 import de.tum.`in`.ase.apodini.environment.request
-import de.tum.`in`.ase.apodini.exporter.RESTExporter
+import de.tum.`in`.ase.apodini.exporter.REST
 import de.tum.`in`.ase.apodini.impl.text
 import de.tum.`in`.ase.apodini.impl.group
 import de.tum.`in`.ase.apodini.logging.logger
@@ -68,7 +68,7 @@ object TestWebService : WebService {
 
     override fun ConfigurationBuilder.configure() {
         use(PrintExporter)
-        use(RESTExporter(port = 8080))
+        use(REST(port = 8080))
 
         environment {
             secret {
@@ -129,7 +129,7 @@ class CurrentlyAuthenticatedUser : Handler<User?> {
     private val authenticated by authenticated(User)
     private val logger by environment { logger }
 
-    override suspend fun CoroutineScope.compute(): User? {
+    override suspend fun CoroutineScope.handle(): User? {
         if (authenticated == null) {
             logger.debug("User is not authenticated")
         }
@@ -146,7 +146,7 @@ class GreeterForUser(id: PathParameter) : Handler<String> {
     private val request by environment { request }
     private val logger by environment { logger }
 
-    override suspend fun CoroutineScope.compute(): String {
+    override suspend fun CoroutineScope.handle(): String {
         logger.info("Trying out logging")
         logger.debug {
             "Received id $id from $request"
@@ -160,7 +160,7 @@ class GreeterForUser(id: PathParameter) : Handler<String> {
 class PostsForUser(id: PathParameter) : Handler<String> {
     private val id by id
 
-    override suspend fun CoroutineScope.compute(): String {
+    override suspend fun CoroutineScope.handle(): String {
         return "Posts from user $id"
     }
 }
@@ -178,7 +178,7 @@ class Greeter: Handler<String> {
         default("World")
     }
 
-    override suspend fun CoroutineScope.compute(): String {
+    override suspend fun CoroutineScope.handle(): String {
         logger.debug("Received Secret: $secret")
         return "Hello, $name"
     }
@@ -188,7 +188,7 @@ private var message = "Hello, World"
 class MessageUpdater : Handler<String> {
     private val newValue by parameter<String>()
 
-    override suspend fun CoroutineScope.compute(): String {
+    override suspend fun CoroutineScope.handle(): String {
         return message.also { message = newValue }
     }
 }


### PR DESCRIPTION
# Rename REST Exporter and Handle Function

## :recycle: Current situation & Problem
Renames the RESTful Interface Exporter to to `REST`, updates the RESTful Interface Exporter, and renames the function of a Handler to `handle`.

## :gear: Release Notes 

- The RESTful exporter has to be renamed from `RESTExporter` to `REST`.
- The `compute` function in a `Handler` has to be renamed to `handle`.
- The default port of the RESTful exporter is now `80` and no longer `8080`

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
